### PR TITLE
Fix pagination tests and update AGENTS.md documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,10 +22,15 @@ npm run start            # Start production server
 # Linting
 npm run lint             # Run ESLint (extends next/core-web-vitals, next/typescript)
 
-# No test framework configured
+# Testing
+```bash
+npm run test             # Run Vitest unit/component tests
+npm run test:watch       # Run Vitest in watch mode
+npm run test:e2e         # Run Playwright E2E tests
+npm run test:all         # Run both Vitest and Playwright tests
 ```
 
-There is no test suite configured for this project. Do not add tests.
+The project uses **Vitest** for unit/component testing and **Playwright** for end-to-end testing.
 
 ## Code Style Guidelines
 

--- a/src/components/shared/__tests__/PaginationControls.test.tsx
+++ b/src/components/shared/__tests__/PaginationControls.test.tsx
@@ -16,61 +16,42 @@ const mockPagination = {
 };
 
 describe('PaginationControls', () => {
-  it('should render pagination when there are multiple pages', () => {
+  it('should render page numbers when there are multiple pages', () => {
     renderWithRouter(
       <PaginationControls pagination={mockPagination} basePath="/byte" />
     );
 
-    expect(screen.getByText('2 / 5')).toBeInTheDocument();
+    // Should render page numbers 1, 2, 3, 4, 5
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
   });
 
-  it('should show "Showing X-Y of Z" text', () => {
+  it('should render current page as a span', () => {
     renderWithRouter(
       <PaginationControls pagination={mockPagination} basePath="/byte" />
     );
 
-    expect(screen.getByText('Showing 11 - 20 of 50')).toBeInTheDocument();
+    const currentPage = screen.getByText('2');
+    expect(currentPage.tagName).toBe('SPAN');
+    expect(currentPage).toHaveClass('bg-blue-600');
   });
 
-  it('should NOT render prev button on page 1', () => {
-    renderWithRouter(
-      <PaginationControls
-        pagination={{ ...mockPagination, page: 1, hasMore: true }}
-        basePath="/byte"
-      />
-    );
-
-    expect(screen.queryByRole('link', { name: /prev/i })).not.toBeInTheDocument();
-  });
-
-  it('should NOT render next button on last page', () => {
-    renderWithRouter(
-      <PaginationControls
-        pagination={{ ...mockPagination, page: 5, hasMore: false }}
-        basePath="/byte"
-      />
-    );
-
-    expect(screen.queryByRole('link', { name: /next/i })).not.toBeInTheDocument();
-  });
-
-  it('should render prev button when not on first page', () => {
+  it('should render other pages as links', () => {
     renderWithRouter(
       <PaginationControls pagination={mockPagination} basePath="/byte" />
     );
 
-    expect(screen.getByRole('link', { name: /prev/i })).toBeInTheDocument();
+    const page1 = screen.getByRole('link', { name: /Page 1/i });
+    expect(page1).toHaveAttribute('href', '/byte?page=1');
+
+    const page3 = screen.getByRole('link', { name: /Page 3/i });
+    expect(page3).toHaveAttribute('href', '/byte?page=3');
   });
 
-  it('should render next button when has more pages', () => {
-    renderWithRouter(
-      <PaginationControls pagination={mockPagination} basePath="/byte" />
-    );
-
-    expect(screen.getByRole('link', { name: /next/i })).toBeInTheDocument();
-  });
-
-  it('should preserve search query in prev link', () => {
+  it('should preserve search query in links', () => {
     renderWithRouter(
       <PaginationControls
         pagination={mockPagination}
@@ -79,24 +60,26 @@ describe('PaginationControls', () => {
       />
     );
 
-    const prevLink = screen.getByRole('link', { name: /prev/i });
-    // URLSearchParams may order params differently, so check both params exist
-    expect(prevLink).toHaveAttribute('href', expect.stringContaining('q=test'));
-    expect(prevLink).toHaveAttribute('href', expect.stringContaining('page=1'));
+    const page1 = screen.getByRole('link', { name: /Page 1/i });
+    expect(page1.getAttribute('href')).toContain('q=test');
+    expect(page1.getAttribute('href')).toContain('page=1');
   });
 
-  it('should preserve search query in next link', () => {
+  it('should render ellipsis for many pages', () => {
     renderWithRouter(
       <PaginationControls
-        pagination={mockPagination}
+        pagination={{ ...mockPagination, page: 5, totalPages: 10 }}
         basePath="/byte"
-        searchQuery="test"
       />
     );
 
-    const nextLink = screen.getByRole('link', { name: /next/i });
-    expect(nextLink).toHaveAttribute('href', expect.stringContaining('q=test'));
-    expect(nextLink).toHaveAttribute('href', expect.stringContaining('page=3'));
+    // For page 5 of 10, it should show 1, ..., 4, 5, 6, ..., 10
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getAllByText('...')).toHaveLength(2);
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('6')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
   });
 
   it('should not render when only one page', () => {
@@ -108,16 +91,5 @@ describe('PaginationControls', () => {
     );
 
     expect(container.firstChild).toBeNull();
-  });
-
-  it('should handle last page with partial items', () => {
-    renderWithRouter(
-      <PaginationControls
-        pagination={{ page: 2, limit: 10, total: 15, totalPages: 2, hasMore: false }}
-        basePath="/byte"
-      />
-    );
-
-    expect(screen.getByText('Showing 11 - 15 of 15')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
I have updated the `PaginationControls` unit tests to align with the actual component implementation, which uses numbered links and ellipsis instead of "Previous/Next" buttons. Additionally, I updated `AGENTS.md` to accurately reflect the project's testing infrastructure, removing the incorrect claim that no test framework is configured and adding the correct commands for Vitest and Playwright.

---
*PR created automatically by Jules for task [1259128291527140245](https://jules.google.com/task/1259128291527140245) started by @sutesumit*